### PR TITLE
Events sorting mechanism created

### DIFF
--- a/src/main/java/seedu/address/model/EventList.java
+++ b/src/main/java/seedu/address/model/EventList.java
@@ -1,12 +1,12 @@
 package seedu.address.model;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.List;
-
 import javafx.collections.ObservableList;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.UniqueEventList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Wraps all data at the event-list level
@@ -80,6 +80,10 @@ public class EventList implements ReadOnlyEventList {
      */
     public void removeEvent(Event key) {
         events.remove(key);
+    }
+
+    public List<Event> getSortedEventList() {
+        return events.getSortedEventList();
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -1,15 +1,15 @@
 package seedu.address.model.event;
 
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-
 import java.util.Date;
 import java.util.Objects;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 /**
  * Represents a Event in the event list.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Event {
+public class Event implements Comparable<Event> {
 
     // Identity fields
     private final EventName eventName;
@@ -91,5 +91,10 @@ public class Event {
                     .append(getEndTime());
         }
         return builder.toString();
+    }
+
+    @Override
+    public int compareTo(Event other) {
+        return this.getStartTime().compareTo(other.getStartTime()) < 0 ? -1 : 1;
     }
 }

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -1,16 +1,16 @@
 package seedu.address.model.event;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-
-import java.util.Iterator;
-import java.util.List;
-
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 
 /**
@@ -19,7 +19,7 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
  * events uses Event#isSameEvent(Event) for equality so as to ensure that the event being added or updated is
  * unique in terms of identity in the UniqueEventList. However, the removal of a event uses Event#equals(Object) so
  * as to ensure that the Event with exactly the same fields will be removed.
- *
+ * <p>
  * Supports a minimal set of list operations.
  *
  * @see Event#isSameEvent(Event)
@@ -95,6 +95,12 @@ public class UniqueEventList implements Iterable<Event> {
         }
 
         internalList.setAll(events);
+    }
+
+    public List<Event> getSortedEventList() {
+        List<Event> result = this.internalList;
+        Collections.sort(result);
+        return result;
     }
 
     /**


### PR DESCRIPTION
Sorted events list now can be queried from the events list. The general assumption is that only start time matters so we sort only by the start time (event that starts earlier goes first)